### PR TITLE
Enhance MSSQL Initialization Script with Dynamic Path Check 

### DIFF
--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -14,7 +14,6 @@ services:
       - '64109:3306'
     volumes:
       - ./sql/mysql:/docker-entrypoint-initdb.d
-#      - "./sql/mysql/mysql_create_and_fill_tables.sql:/docker-entrypoint-initdb.d/12.sql"
     healthcheck:
       test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
       interval: 10s
@@ -36,22 +35,16 @@ services:
     ports:
       - '59530:5432'
     volumes:
-#      - ./sql/postgres/setup.sh:/docker-entrypoint-initdb.d/initdb.sh
       - ./sql/postgres/pg_create_and_fill_tables.sql:/docker-entrypoint-initdb.d/init.sql
   sqlserver:
     container_name: uf-sqlserver
     build:
       context: .
       dockerfile: sql/sqlserver/Dockerfile
-#    image: 'mcr.microsoft.com/mssql/server:latest'
-#    environment:
-#      - 'ACCEPT_EULA=yes'
-#      - 'MSSQL_PID=express'
-#      - 'MSSQL_SA_PASSWORD=verYs3cret'
     ports:
       - '64110:1433'
     healthcheck:
-      test: /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P "verYs3cret" -Q "CREATE DATABASE TestDB"
+      test: /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "verYs3cret" -C -Q "CREATE DATABASE TestDB"
       interval: 10s
       timeout: 3s
       retries: 10

--- a/docker/sql/sqlserver/run-initialization.sh
+++ b/docker/sql/sqlserver/run-initialization.sh
@@ -26,6 +26,7 @@ else
         SQLCMDAPPPATH="/opt/mssql-tools18/bin/sqlcmd"
     else
         echo "Not found path to sqlcmd util!!"
+        exit 1
     fi
 fi
 

--- a/docker/sql/sqlserver/run-initialization.sh
+++ b/docker/sql/sqlserver/run-initialization.sh
@@ -8,9 +8,30 @@
 
 #run the setup script to create the DB and the schema in the DB
 #do this in a loop because the timing for when the SQL instance is ready is indeterminate
+
+# Starting with SQL Server 2022 (16.x) CU 14 and SQL Server 2019 (15.x) CU 28,
+# the container images include the new mssql-tools18 package.
+# The previous directory /opt/mssql-tools/bin is being phased out.
+# The new directory for Microsoft ODBC 18 tools is /opt/mssql-tools18/bin,
+# aligning with the latest tools offering.
+SQLCMDAPPPATH="/opt/mssql-tools18/bin/sqlcmd"
+
+if [ -d /opt/mssql-tools/bin ]; then
+    echo "/opt/mssql-tools/bin directory exists"
+    SQLCMDAPPPATH="/opt/mssql-tools/bin/sqlcmd"
+else
+    echo "/opt/mssql-tools/bin directory DOESN'T exists"
+    if [ -d /opt/mssql-tools18/bin ]; then
+        echo "/opt/mssql-tools18/bin directory exists"
+        SQLCMDAPPPATH="/opt/mssql-tools18/bin/sqlcmd"
+    else
+        echo "Not found path to sqlcmd util!!"
+    fi
+fi
+
 for i in {1..50};
 do
-    /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P $MSSQL_SA_PASSWORD -d master -i create-database.sql
+    $SQLCMDAPPPATH -S localhost -U sa -P $MSSQL_SA_PASSWORD -d master -C -i create-database.sql
     if [ $? -eq 0 ]
     then
         echo "setup.sql completed"
@@ -20,28 +41,3 @@ do
         sleep 1
     fi
 done
-#!/bin/bash
-
-# Wait 60 seconds for SQL Server to start up by ensuring that
-# calling SQLCMD does not return an error code, which will ensure that sqlcmd is accessible
-# and that system and user databases return "0" which means all databases are in an "online" state
-# https://docs.microsoft.com/en-us/sql/relational-databases/system-catalog-views/sys-databases-transact-sql?view=sql-server-2017
-#
-#DBSTATUS=1
-#ERRCODE=1
-#i=0
-#
-#while [[ $DBSTATUS -ne 0 ]] && [[ $i -lt 60 ]] && [[ $ERRCODE -ne 0 ]]; do
-#	i=$i+1
-#	DBSTATUS=$(/opt/mssql-tools/bin/sqlcmd -h -1 -t 1 -U sa -P $MSSQL_SA_PASSWORD -Q "SET NOCOUNT ON; Select SUM(state) from sys.databases")
-#	ERRCODE=$?
-#	sleep 1
-#done
-#
-#if [ $DBSTATUS -ne 0 ] OR [ $ERRCODE -ne 0 ]; then
-#	echo "SQL Server took more than 60 seconds to start up or one or more databases are not in an ONLINE state"
-#	exit 1
-#fi
-#
-## Run the setup script to create the DB and the schema in the DB
-#/opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P $MSSQL_SA_PASSWORD -d master -i create-database.sql


### PR DESCRIPTION
## Problem  
Recent changes in MSSQL Docker images replaced `/opt/mssql-tools/bin` with `/opt/mssql-tools18/bin` as the directory for the `sqlcmd` utility. This caused the initialization script to fail when the older path was no longer available, resulting in the following error:  

> /usr/src/app/run-initialization.sh: line 13: /opt/mssql-tools/bin/sqlcmd: No such file or directory


## Solution  
The initialization script now dynamically checks the availability of both directories (`/opt/mssql-tools/bin` and `/opt/mssql-tools18/bin`) and selects the appropriate path for the `sqlcmd` utility. If neither directory is found, the script logs an error and exits.  

### Updated Script Snippet  
```bash
SQLCMDAPPPATH="/opt/mssql-tools18/bin/sqlcmd"

if [ -d /opt/mssql-tools/bin ]; then
    echo "/opt/mssql-tools/bin directory exists"
    SQLCMDAPPPATH="/opt/mssql-tools/bin/sqlcmd"
else
    echo "/opt/mssql-tools/bin directory DOESN'T exist"
    if [ -d /opt/mssql-tools18/bin ]; then
        echo "/opt/mssql-tools18/bin directory exists"
        SQLCMDAPPPATH="/opt/mssql-tools18/bin/sqlcmd"
    else
        echo "Not found path to sqlcmd util!!"
        exit 1
    fi
fi
```

## Reference
For more details about this change, see Microsoft's official documentation:
[Quickstart: Install SQL Server on Linux Containers](https://learn.microsoft.com/en-us/sql/linux/quickstart-install-connect-docker?view=sql-server-ver16&tabs=cli&pivots=cs1-bash).